### PR TITLE
wip: example for use form state

### DIFF
--- a/src/actions/createTask.ts
+++ b/src/actions/createTask.ts
@@ -7,9 +7,9 @@ import { redirect } from "next/navigation";
 
 interface CreateTaskFormState {
     errors: {
-        title?: string[];
-        description?: string[];
-        date?: string[];
+        title?: string;
+        description?: string;
+        date?: string;
     };
 }
 

--- a/src/components/taskForm/TaskForm.tsx
+++ b/src/components/taskForm/TaskForm.tsx
@@ -31,7 +31,7 @@ const TaskForm = () => {
   //                 labelPlacement="outside"
   //                 placeholder="Title"
   //                 isInvalid={!!formState.errors.title}
-  //                 errorMessage={formState.errors.title?.join(", ")}
+  //                 errorMessage={formState.errors.title}
   //             />
   //             <NextUITextarea
   //                 name={TASK_FORM_NAMES_CONSTANTS.DESCRIPTION}
@@ -39,7 +39,7 @@ const TaskForm = () => {
   //                 labelPlacement="outside"
   //                 placeholder="Description"
   //                 isInvalid={!!formState.errors.description}
-  //                 errorMessage={formState.errors.description?.join(", ")}
+  //                 errorMessage={formState.errors.description}
   //             />
   //             <NextUIInput
   //                 name={TASK_FORM_NAMES_CONSTANTS.DATE}
@@ -47,7 +47,7 @@ const TaskForm = () => {
   //                 labelPlacement="outside"
   //                 placeholder="Date"
   //                 isInvalid={!!formState.errors.date}
-  //                 errorMessage={formState.errors.date?.join(", ")}
+  //                 errorMessage={formState.errors.date}
   //             />
   //             <Button type="submit">Submit</Button>
   //         </div>

--- a/src/components/taskForm/TaskForm.tsx
+++ b/src/components/taskForm/TaskForm.tsx
@@ -1,47 +1,80 @@
 "use client";
 
+import { Button, Input as NextUIInput, Textarea as NextUITextarea } from "@nextui-org/react";
 import { useFormState } from "react-dom";
-import { Button, Input, Textarea } from "@nextui-org/react";
 
 import { createTask } from "@/actions/createTask";
 import { TASK_FORM_NAMES_CONSTANTS } from "@/constants/taskFormNamesConstants";
 
-const TaskForm = () => {
-    const [formState, action] = useFormState(createTask, {
-        errors: {},
-    });
+import { Input } from "../ui/input";
+import { TextArea } from "../ui/textarea";
 
-    return (
-        <form action={action}>
-            <div className="flex flex-col gap-4 bg-green-300 w-80">
-                <Input
-                    name={TASK_FORM_NAMES_CONSTANTS.TITLE}
-                    label="Title"
-                    labelPlacement="outside"
-                    placeholder="Title"
-                    isInvalid={!!formState.errors.title}
-                    errorMessage={formState.errors.title?.join(", ")}
-                />
-                <Textarea
-                    name={TASK_FORM_NAMES_CONSTANTS.DESCRIPTION}
-                    label="Description"
-                    labelPlacement="outside"
-                    placeholder="Description"
-                    isInvalid={!!formState.errors.description}
-                    errorMessage={formState.errors.description?.join(", ")}
-                />
-                <Input
-                    name={TASK_FORM_NAMES_CONSTANTS.DATE}
-                    label="Date"
-                    labelPlacement="outside"
-                    placeholder="Date"
-                    isInvalid={!!formState.errors.date}
-                    errorMessage={formState.errors.date?.join(", ")}
-                />
-                <Button type="submit">Submit</Button>
-            </div>
-        </form>
-    );
+const initialState = {
+  title: "",
+  description: "",
+  date: "",
+};
+
+const TaskForm = () => {
+  const [formState, action] = useFormState(createTask, {
+    errors: initialState,
+  });
+
+  // REVIEW: This is an example of how to use the useFormState hook in nextui components
+
+  //   return (
+  //     <form action={action}>
+  //         <div className="flex flex-col gap-4 bg-green-300 w-80">
+  //             <NextUIInput
+  //                 name={TASK_FORM_NAMES_CONSTANTS.TITLE}
+  //                 label="Title"
+  //                 labelPlacement="outside"
+  //                 placeholder="Title"
+  //                 isInvalid={!!formState.errors.title}
+  //                 errorMessage={formState.errors.title?.join(", ")}
+  //             />
+  //             <NextUITextarea
+  //                 name={TASK_FORM_NAMES_CONSTANTS.DESCRIPTION}
+  //                 label="Description"
+  //                 labelPlacement="outside"
+  //                 placeholder="Description"
+  //                 isInvalid={!!formState.errors.description}
+  //                 errorMessage={formState.errors.description?.join(", ")}
+  //             />
+  //             <NextUIInput
+  //                 name={TASK_FORM_NAMES_CONSTANTS.DATE}
+  //                 label="Date"
+  //                 labelPlacement="outside"
+  //                 placeholder="Date"
+  //                 isInvalid={!!formState.errors.date}
+  //                 errorMessage={formState.errors.date?.join(", ")}
+  //             />
+  //             <Button type="submit">Submit</Button>
+  //         </div>
+  //     </form>
+  // );
+
+  // REVIEW: This is an example of how to use the useFormState hook in react/html components
+
+  return (
+    <form action={action}>
+      <div className="flex flex-col gap-4 bg-green-300 w-80">
+        <Input name="title" placeholder="Title" />
+        {formState?.errors.title && (
+          <p className="text-red-500">{formState?.errors.title}</p>
+        )}
+        <TextArea name={TASK_FORM_NAMES_CONSTANTS.DESCRIPTION} />
+        {formState?.errors.description && (
+          <p className="text-red-500">{formState?.errors.description}</p>
+        )}
+        <Input name={TASK_FORM_NAMES_CONSTANTS.DATE} placeholder="Date" />
+        {formState?.errors.date && (
+          <p className="text-red-500">{formState?.errors.date}</p>
+        )}
+        <Button type="submit">Submit</Button>
+      </div>
+    </form>
+  );
 };
 
 export default TaskForm;

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -1,0 +1,7 @@
+import { ComponentProps, forwardRef } from "react";
+
+export const Input = forwardRef<HTMLInputElement, ComponentProps<"input">>(
+  ({ ...props }, ref) => <input ref={ref} {...props} />
+);
+
+Input.displayName = "Input";

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,8 @@
+import { ComponentProps, forwardRef } from "react";
+
+export const TextArea = forwardRef<
+  HTMLTextAreaElement,
+  ComponentProps<"textarea">
+>(({ ...props }, ref) => <textarea ref={ref} {...props} />);
+
+TextArea.displayName = "TextArea";


### PR DESCRIPTION
Este PR mostra o pq dos erros usando os componentes do next-ui não "sumirem" após o envio e em contrapartida, usando os componentes nativos do html (input, textarea e etc) "sumirem".

> Ps.: Só comentar/descomentar a parte que tem como `REVIEW:`